### PR TITLE
Fix 1.21 Item Drop

### DIFF
--- a/scripts/怪物掉落.js
+++ b/scripts/怪物掉落.js
@@ -1,4 +1,18 @@
-
+let ItemStack = org.bukkit.inventory.ItemStack;
+let Material = org.bukkit.Material;
+//安全获取物品
+function getItemSafe(item) {
+  if (item === null) {
+    return new ItemStack(Material.AIR);
+  }
+  //复制类型数量Meta
+  let safeItem = new ItemStack(item.getType());
+  safeItem.setAmount(item.getAmount());
+  if (item.hasItemMeta()) {
+    safeItem.setItemMeta(item.getItemMeta());
+  }
+  return safeItem;
+}
 //概率
 function chanceEvent(chance) {
   if (typeof chance !== 'number' || chance < 0 || chance > 1) {
@@ -46,7 +60,7 @@ function zidingyiguaiwu(event,killer) {
   if (levelIndex !== -1) {
     const level = levels[levelIndex];
     const slimefunItem = getSfItemById(level.item);
-    const itemStack = new org.bukkit.inventory.ItemStack(slimefunItem.getItem());
+    const itemStack = getItemSafe(slimefunItem.getItem());
     const location = event.getLocation(); 
     const world = location.getWorld();
 
@@ -87,7 +101,7 @@ function zidingyiguaiwuByzidingyiwuqi(killer, entity) {
 
   const drop = drops[dropIndex];
   const slimefunItem = getSfItemById(drop.item);
-  const itemStack = new org.bukkit.inventory.ItemStack(slimefunItem.getItem());
+  const itemStack = getItemSafe(slimefunItem.getItem());
   const location = entity.getLocation();
   const world = entity.getWorld();
 
@@ -128,7 +142,7 @@ function pickaxeDropItems(player, e) {
 
   const drop = drops[dropIndex];
   const slimefunItem = getSfItemById(drop.item);
-  const itemStack = new org.bukkit.inventory.ItemStack(slimefunItem.getItem());
+  const itemStack = getItemSafe(slimefunItem.getItem());
   const location = block.getLocation();
   const world = block.getWorld();
 

--- a/scripts/无尽增幅卡.js
+++ b/scripts/无尽增幅卡.js
@@ -1,3 +1,39 @@
+let ItemStack = org.bukkit.inventory.ItemStack;
+let Material = org.bukkit.Material;
+//安全获取物品
+function getItemSafe(item) {
+  if (item === null) {
+    return new ItemStack(Material.AIR);
+  }
+  let safeItem = new ItemStack(item.getType());
+  safeItem.setAmount(item.getAmount());
+  if (item.hasItemMeta()) {
+    safeItem.setItemMeta(item.getItemMeta());
+  }
+  return safeItem;
+}
+function onUse(event) {
+  let player = event.getPlayer();
+  let world = player.getWorld();
+  let eyeLocation = player.getEyeLocation();
+  let direction = eyeLocation.getDirection();
+  let startLocation = eyeLocation.clone().subtract(0, 0.8, 0).add(direction);
+  let maxDistance = 5;
+  let rayTraceResults = world.rayTrace(startLocation, direction, maxDistance, org.bukkit.FluidCollisionMode.ALWAYS, true, 0, null);
+
+  if (rayTraceResults == null) {
+    return;
+  }
+
+  let entity = rayTraceResults.getHitEntity();
+  if (entity instanceof org.bukkit.entity.Bee) {
+    let slimefunItem = getSfItemById("JP_BEE");
+    let item = getItemSafe(slimefunItem.getItem());
+    entity.remove();
+    let location = entity.getLocation();
+    world.dropItemNaturally(location, item);
+  }
+}
 function onUse(event) {
     const player = event.getPlayer();
     if(event.getHand() !== org.bukkit.inventory.EquipmentSlot.HAND){
@@ -45,7 +81,7 @@ function onUse(event) {
         sendMessage(player, "毛都没获得");
     } else {
         const slimefunItem = getSfItemById(selectedItem);
-        const itemstack = new org.bukkit.inventory.ItemStack(slimefunItem.getItem());
+        const itemstack = getItemSafe(slimefunItem.getItem());
         itemstack.setAmount(1);
         if (invs.firstEmpty() === -1) {
             player.getWorld().dropItemNaturally(player.getLocation(), itemstack);

--- a/scripts/蜜蜂捕捉器.js
+++ b/scripts/蜜蜂捕捉器.js
@@ -1,3 +1,17 @@
+let ItemStack = org.bukkit.inventory.ItemStack;
+let Material = org.bukkit.Material;
+//安全获取物品
+function getItemSafe(item) {
+  if (item === null) {
+    return new ItemStack(Material.AIR);
+  }
+  let safeItem = new ItemStack(item.getType());
+  safeItem.setAmount(item.getAmount());
+  if (item.hasItemMeta()) {
+    safeItem.setItemMeta(item.getItemMeta());
+  }
+  return safeItem;
+}
 function onUse(event) {
   let player = event.getPlayer();
   let world = player.getWorld();
@@ -14,7 +28,7 @@ function onUse(event) {
   let entity = rayTraceResults.getHitEntity();
   if (entity instanceof org.bukkit.entity.Bee) {
     let slimefunItem = getSfItemById("JP_BEE");
-    let item = new org.bukkit.inventory.ItemStack(slimefunItem.getItem());
+    let item = getItemSafe(slimefunItem.getItem());
     entity.remove();
     let location = entity.getLocation();
     world.dropItemNaturally(location, item);


### PR DESCRIPTION
修复1.21 **特殊怪物无法正确掉落战利品，蜜蜂捕捉器无法掉落机械蜜蜂，无尽增幅卡无法正确抽取物品**